### PR TITLE
Fix: Corrected key spelling from `edit_suggestions` to `edit_suggestion` in Scene Editor response

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -77,7 +77,7 @@ async def edit_scene(request: Request, data: SceneRequest, x_user_agreement: str
             resp.raise_for_status()
             result = resp.json()
             analysis = result["choices"][0]["message"]["content"].strip()
-            return {"edit_suggestions": analysis}
+            return {"edit_suggestion": analysis}
     except httpx.HTTPStatusError as e:
         raise HTTPException(e.response.status_code, e.response.text)
     except Exception as e:


### PR DESCRIPTION
This PR fixes a mismatch between the backend response key and frontend expectation in Scene Editor.

- Corrected the spelling of the response key from `edit_suggestions` to `edit_suggestion` in `fastapp_api.py` under both `main` and `scene-editor` branches.
- This resolves the frontend error where the edit output was not rendering and defaulted to "An error occurred."
- Verified that Scene Analyzer remains unaffected.

This change aligns the response with the expected structure used in `index.html`, ensuring edit suggestions display correctly after user submits a scene.

Tested on both local and deployed environments.

Fixes issue: Scene Editor returns empty or error despite valid API response.
