### PR TITLE
Fix input payload for scene submission in Analyzer and Editor

### DIFF
--- a/frontend_dist/index.html
+++ b/frontend_dist/index.html
@@ -178,7 +178,7 @@ lastAnalyzed = scene;
         "Content-Type": "application/json",
         "x-user-agreement": "true"
       },
-      body: JSON.stringify({ scene })
+      body: JSON.stringify({ scene: userInputText })
     });
     const data = await res.json();
     const raw = data.analysis || "";
@@ -276,7 +276,7 @@ if (scene === lastEdited && lastEditOutput) {
         "Content-Type": "application/json",
         "x-user-agreement": "true"
       },
-     body: JSON.stringify({ scene })
+     body: JSON.stringify({ scene: userInputText })
     });
 
     const data = await res.json();


### PR DESCRIPTION
Fixed the frontend fetch calls for /analyze and /edit by explicitly passing scene: userInputText in the request body. This resolves the 400 Bad Request error caused by undefined input in both endpoints. Ensures proper scene data is sent to the backend.