### PR TITLE
Revert: Restore edit_suggestions key in fastapp_api response

### DIFF
--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -77,7 +77,7 @@ async def edit_scene(request: Request, data: SceneRequest, x_user_agreement: str
             resp.raise_for_status()
             result = resp.json()
             analysis = result["choices"][0]["message"]["content"].strip()
-            return {"edit_suggestion": analysis}
+            return {"edit_suggestions": analysis}
     except httpx.HTTPStatusError as e:
         raise HTTPException(e.response.status_code, e.response.text)
     except Exception as e:


### PR DESCRIPTION
Reverted the response key from edit_suggestion back to edit_suggestions in fastapp_api.py to maintain consistency with frontend expectations and original implementation.

This ensures that Scene Editor displays results correctly and avoids frontend parsing errors caused by mismatched response key names.

✅ Fix tested with both /edit and /analyze endpoints working as expected.