### PR TITLE
Increase HTTPX timeout to 180 seconds for scene analysis requests

### DIFF
--- a/logic/analyzer.py
+++ b/logic/analyzer.py
@@ -232,7 +232,7 @@ async def analyze_scene(scene: str) -> dict:
     }
 
     try:
-        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(180.0)) as client:
             resp = await client.post(
                 "https://openrouter.ai/api/v1/chat/completions",
                 headers={


### PR DESCRIPTION
Updated analyzer request handling to use httpx.Timeout(180.0) to better accommodate longer AI processing times, especially for complex or large scene submissions.

This change helps prevent premature timeout errors that previously caused incomplete or failed scene analyses.

No other logic or output formatting changes were made — core cinematic benchmarks and analysis flow remain intact.

Impact:

Scene Analyzer can now process longer scenes without hitting default timeout limits.

No changes required on the frontend.

Deployment recommended to apply the extended timeout in production.